### PR TITLE
flutter 2.5.2, FocusOnKeyCallback need return a keyeventresult

### DIFF
--- a/lib/src/components/bs_wrapper_option.dart
+++ b/lib/src/components/bs_wrapper_option.dart
@@ -107,7 +107,7 @@ class _BsWrapperOptionsState extends State<BsWrapperOptions> {
       if(event.logicalKey == LogicalKeyboardKey.escape)
         widget.onClose();
 
-      return false;
+      return KeyEventResult.ignored;
     });
     _focusNode.addListener(onFocus);
     _focusNode.requestFocus();


### PR DESCRIPTION
bs_wrapper_option.dart:108:14: Error: A value of type 'bool' can't be returned from a
function with return type 'KeyEventResult'.

flutter 2.5.2, FocusOnKeyCallback need return a keyeventresult.